### PR TITLE
Add info box for email confirmation and sign-ups disabled.

### DIFF
--- a/src/routes/(marketing)/(auth)/register/+page.svelte
+++ b/src/routes/(marketing)/(auth)/register/+page.svelte
@@ -6,6 +6,12 @@
 	import RegisterForm from './register-form.svelte';
 
 	export let data;
+	export let form;
+
+	// Check form status
+	$: registrationSuccess = form?.success;
+	$: userEmail = form?.email;
+	$: signupDisabled = form?.signupDisabled;
 </script>
 
 <svelte:head>
@@ -28,17 +34,45 @@
 		</Card.Title>
 	</Card.Header>
 	<Card.Content class="flex flex-col gap-4">
-		<SocialsAuth />
-
-		<div class="flex flex-col gap-3">
-			<p class="text-sm text-muted-foreground">
-				Create an account with your email address below.
+		{#if registrationSuccess}
+			<Alert.Root class="mb-6" variant="default">
+				<Alert.Title>Verification email sent</Alert.Title>
+				<Alert.Description>
+					We've sent a confirmation email to <strong>{userEmail}</strong>.
+					Please check your inbox and follow the instructions to verify your
+					account.
+				</Alert.Description>
+			</Alert.Root>
+			<p class="text-center text-sm">
+				Didn't receive the email? Check your spam folder or <a
+					href="/register"
+					class="underline">try again</a
+				>.
 			</p>
-			<RegisterForm data={data.form} />
-			<div class="mt-4 text-center text-sm">
-				Already have an account?
-				<a href="/login" class="underline">Log in</a>.
+		{:else if signupDisabled}
+			<Alert.Root class="mb-6" variant="destructive">
+				<Alert.Title>Signups temporarily disabled</Alert.Title>
+				<Alert.Description>
+					We're sorry, but new user registration is currently disabled. Please
+					try again later or contact support for assistance.
+				</Alert.Description>
+			</Alert.Root>
+			<p class="text-center text-sm">
+				Already have an account? <a href="/login" class="underline">Log in</a>.
+			</p>
+		{:else}
+			<SocialsAuth />
+
+			<div class="flex flex-col gap-3">
+				<p class="text-sm text-muted-foreground">
+					Create an account with your email address below.
+				</p>
+				<RegisterForm data={data.form} />
+				<div class="mt-4 text-center text-sm">
+					Already have an account?
+					<a href="/login" class="underline">Log in</a>.
+				</div>
 			</div>
-		</div>
+		{/if}
 	</Card.Content>
 </Card.Root>

--- a/src/routes/(marketing)/(auth)/register/register-form.svelte
+++ b/src/routes/(marketing)/(auth)/register/register-form.svelte
@@ -23,7 +23,7 @@
 	<Form.Errors {form} />
 	<Form.Field {form} name="email">
 		<Form.Control let:attrs>
-			<Form.Label class="mb-2">Emial</Form.Label>
+			<Form.Label class="mb-2">Email</Form.Label>
 			<Input
 				{...attrs}
 				type="email"


### PR DESCRIPTION
Improved the sign-up page with a couple of little tweaks 😉 

1. If sign-ups were disabled in Supabase I added a specific alert box for that, rather than the form throwing a generic error to the user. That ways an admin can disable sign-ups directly in the DB if they have too much demand; and users know to come back later.
2. When signing up, after a user enters their desired email and password, the page automatically tried to forward them to the dashboard, however most Supabase instances have email verification first before a user is allowed to sign-in. So this would fail and just redirect them to the login page with no messages (a very similar looking page, and some users might even think that they are trying to sign-up again as it failed.).

However even though I didn't implement it, if some people want to disable email verification then this would be confusing. I just realized this after I submitted this PR. Maybe an option to say if they have verification enabled or disabled could be in order; but that's a later task.

3. Small fix but 'Email' was misspelled as '_Emial_' on both forms. 😄 